### PR TITLE
Fix bug where moving down from initial position crashes game

### DIFF
--- a/games/frogger/frogger.js
+++ b/games/frogger/frogger.js
@@ -195,6 +195,10 @@ class GameManager {
     // Checks to see if the current user position is valid, i.e. on a log.
     // Returns true if user is currently on a log, false if not.
     isValidFrogPosition() {
+        if (gameProps.userRow<0) {
+            return false
+        }
+
         // This could be made more efficient by breaking early, but it's not worth the micro optimization right now
         for (const l of this.rows[gameProps.userRow].logs) {
             if (l.position < gameProps.userColumn + 1 - frogInset && (l.position + l.length) >= gameProps.userColumn + frogInset) {


### PR DESCRIPTION
Turns out, nothing to do with draw or update loops, it was checking the frogs position was valid! When moved down, row -1 was out of bounds in the log array

Closes #11 